### PR TITLE
refactor: remove immediate steps for tmate

### DIFF
--- a/Data_Hoarders.ipynb
+++ b/Data_Hoarders.ipynb
@@ -13,8 +13,7 @@
         "Cr9FE8o1HHdC",
         "2X48Z7Pp-jI_"
       ],
-      "machine_shape": "hm",
-      "include_colab_link": true
+      "machine_shape": "hm"
     },
     "kernelspec": {
       "name": "python3",
@@ -22,16 +21,6 @@
     }
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/vietcode/colab/blob/main/Data_Hoarders.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -60,24 +49,23 @@
         "\n",
         "rclone = True #@param {type: \"boolean\" }\n",
         "speedtest = False #@param {type: \"boolean\" }\n",
-        "ssh = False #@param {type: \"boolean\"}\n",
+        "ssh = True #@param {type: \"boolean\"}\n",
         "\n",
         "# Install libraries\n",
         "if rclone:\n",
-        "  !curl https://rclone.org/install.sh | sudo bash\n",
+        "  !curl https://rclone.org/install.sh &> /dev/null | sudo bash\n",
+        "  !rclone --version\n",
         "\n",
         "if speedtest:\n",
         "  !pip install speedtest-cli 2>&1\n",
         "  !speedtest\n",
         "\n",
         "if ssh:\n",
-        "  !wget https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-i386.tar.xz &> /dev/null\n",
-        "  !mkdir -p tmate \n",
-        "  !tar -xvf tmate-2.4.0-static-linux-i386.tar.xz --strip-components 1 &> /dev/null\n",
-        "  !rm tmate-2.4.0-static-linux-i386.tar.xz\n",
-        "  !./tmate -S /tmp/tmate.sock new-session -d &> /dev/null\n",
+        "  !ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa <<<y 2>&1 >/dev/null\n",
+        "  !curl -L https://github.com/tmate-io/tmate/releases/download/2.4.0/tmate-2.4.0-static-linux-i386.tar.xz &> /dev/null | tar xJC /usr/local/bin --strip-components 1 &> /dev/null\n",
+        "  !tmate -S /tmp/tmate.sock new-session -d &> /dev/null\n",
         "  !sleep 1\n",
-        "  !./tmate -S /tmp/tmate.sock display -p 'Connect to this SSH address: #{tmate_ssh}' "
+        "  !tmate -S /tmp/tmate.sock display -p '#{tmate_ssh}'"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Use `curl` to download instead, and pipe to `tar` to extract to /usr/local/bin.

Also generate a pair of SSH keys.