### PR TITLE
feat: proxy rclone servers to port 80

### DIFF
--- a/Data_Hoarders.ipynb
+++ b/Data_Hoarders.ipynb
@@ -30,7 +30,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/vietcode/colab/blob/main/Data_Hoarders.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/vietcode/colab/blob/rclone/Data_Hoarders.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -277,6 +277,8 @@
       "source": [
         "#@title { display-mode: \"form\" }\n",
         "\n",
+        "from google.colab.output import eval_js\n",
+        "\n",
         "command = \"size\" #@param [\"size\", \"lsd\", \"mkdir\", \"rmdir\", \"mount\", \"ncdu\", \"cat\", \"dedupe\", \"serve dlna\", \"serve ftp\", \"serve http\", \"serve restic\", \"serve sftp\", \"serve webdav\"]\n",
         "name = \"source:\" #@param [\"source:\", \"target:\", \"crypt:\"] { allow-input: true }\n",
         "path = \"\" #@param { type: \"string\" }\n",
@@ -290,6 +292,27 @@
         "    flags += \" --vfs-cache-mode=writes\"\n",
         "\n",
         "  flags += \" --daemon\"\n",
+        "\n",
+        "if \"serve \" in command:\n",
+        "  protocol = command[6:]\n",
+        "  # Default ports by protcol from rclone.\n",
+        "  ports = {\n",
+        "    \"dlna\": 7879,\n",
+        "    \"ftp\": 2121,\n",
+        "    \"http\": 8080,\n",
+        "    \"restic\": 8080,\n",
+        "    \"sftp\": 2022,\n",
+        "    \"webdav\": 8080\n",
+        "  }\n",
+        "  port = ports[protocol]\n",
+        "  # Port 8080 is taken in Colab, switch to 8888.\n",
+        "  if port == 8080:\n",
+        "    flags += \" --addr localhost:8888\"\n",
+        "    port = 8888\n",
+        "\n",
+        "  flags += \" --quiet\"\n",
+        "\n",
+        "  print(\"Serving \" + protocol + \" at \" + eval_js(\"google.colab.kernel.proxyPort(\" + str(port) + \")\"))\n",
         "\n",
         "args = \"'\" + name + \"'\"\n",
         "if path:\n",


### PR DESCRIPTION
If `rclone serve` commands are issued, forward rclone's default port for chosen
protocol to port 80 using `google.colab.kernel.proxyPort`.

Because port 8080 is already in used by Colab, switch the protocols using that
port to 8888.